### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "mongodb": "^2.0.35",
     "mongoose": "^4.0.6",
     "multer": "^0.1.6",
-    "node-uuid": "^1.4.1",
     "nodemailer": "^1.3.0",
     "nodemailer-smtp-transport": "^0.1.13",
     "password-generator": "^0.2.2",
@@ -73,6 +72,7 @@
     "socket.io-redis": "^1.0.0",
     "socketio-sticky-session": "^0.4.1",
     "underscore": "^1.7.0",
+    "uuid": "^3.0.0",
     "yargs": "^1.3.1"
   },
   "devDependencies": {

--- a/src/server/user/models/user.js
+++ b/src/server/user/models/user.js
@@ -9,7 +9,7 @@ var bcrypt = require('bcrypt'),
     jwt = require('jwt-simple'),
     generatePassword = require('password-generator'),
     async = require('async'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     fs = require('fs'),
     _ = require('underscore');
 

--- a/src/upload/upload.js
+++ b/src/upload/upload.js
@@ -1,7 +1,7 @@
 var fs = require('fs'),
     fse = require('fs.extra'),
     async = require('async'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     slug = require('slug');
 
 var config = require(__dirname + '/../config');


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.